### PR TITLE
Corrigindo bug windows com slidy start

### DIFF
--- a/lib/src/utils/file_utils.dart
+++ b/lib/src/utils/file_utils.dart
@@ -2,11 +2,16 @@ import 'dart:io';
 import 'package:path/path.dart';
 import 'package:slidy/src/utils/utils.dart';
 import 'package:slidy/src/utils/output_utils.dart' as output;
+import 'dart:io' show Platform;
 
 void createFile(String path, String type, Function generator) async {
   output.msg("Creating $type...");
-
-  path = path.replaceAll("\\", "/").replaceAll("\"", "");
+  
+  var uri = Platform.script;
+  var pathLinux = uri.toFilePath();
+  if (pathLinux.contains("/")) {
+    path = path.replaceAll("\\", "/").replaceAll("\"", "");
+  }
   if (path.startsWith("/")) path = path.substring(1);
   if (path.endsWith("/")) path = path.substring(0, path.length - 1);
 
@@ -20,9 +25,11 @@ void createFile(String path, String type, Function generator) async {
   }
 
   String name = basename(path);
-
-  File file =
-      File('${dir.path}/${name}_${type.replaceAll("_complete", "")}.dart');
+  var pathToFile = '${dir.path}\\${name}_${type.replaceAll("_complete", "")}.dart';
+  if (pathLinux.contains("/")) {
+    pathToFile = '${dir.path}/${name}_${type.replaceAll("_complete", "")}.dart';
+  }
+  File file = File(pathToFile);
 
   if (file.existsSync()) {
     output.error("already exists a $type $name");


### PR DESCRIPTION
Ao rodar o comando slidy start 

apresentava o seguinte erro 

C:\flutter-projects\lista_presents>slidy start -f                                                                       Unhandled exception:                                                                                                    FileSystemException: Directory listing failed, path = 'lib\*' (OS Error: O sistema nUnhandled exception:                FileSystemException: Directory listing failed, path = 'lib\*' (OS Error: O sistema não pode encontrar o caminho especificado.                                                                                                                   , errno = 3)                                                                                                            #0      _Directory._fillWithDirectoryListing (dart:io-patch/directory_patch.dart:37:68)                                 #1      _Directory.listSync (dart:io/directory_impl.dart:249:5)                                                         #2      start (package:slidy/src/modules/start.dart:14:11)                                                              <asynchronous suspension>                                                                                               #3      StartCommand.run (package:slidy/src/command/start_command.dart:24:5)                                            #4      CommandRunner.runCommand (package:args/command_runner.dart:197:27)                                              <asynchronous suspension>                                                                                               #5      CommandRunner.run.<anonymous closure> (package:args/command_runner.dart:112:25)                                 #6      new Future.sync (dart:async/future.dart:224:31)                                                                 #7      CommandRunner.run (package:args/command_runner.dart:112:14)                                                     #8      executeCommand (file:///C:/Users/Evandro%20Mendes/AppData/Roaming/Pub/Cache/hosted/pub.dartlang.org/slidy-1.0.0+1/bin/main.dart:33:10)                                                                                                  #9      main (file:///C:/Users/Evandro%20Mendes/AppData/Roaming/Pub/Cache/hosted/pub.dartlang.org/slidy-1.0.0+1/bin/main.dart:12:5)                                                                                                             #10     _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:299:32)                                #11     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:172:12)   

Minha plataforma é o Windows 10 apos essa correção funcionou para mim antes de aprovar favor garantir que funciona em linux ou mac me desculpe não pude testar 