### PR TITLE
Start command flags

### DIFF
--- a/README-PT.md
+++ b/README-PT.md
@@ -127,6 +127,10 @@ slidy start -s mobx
 ```
 slidy start -p flutter_modular -s mobx
 ```
+O comando avisa que irá apagar a pasta lib/ e pede a confimação. Caso não queira ver esse aviso, adicione a flag -e (do inglês "erase", apagar):
+```
+slidy start -p flutter_modular -s mobx -e
+```
 
 ### run:
 

--- a/README-PT.md
+++ b/README-PT.md
@@ -116,7 +116,7 @@ slidy start -p flutter_modular
 ```
 * Gerenciador de estado: 
 ```
--s <gerenciador_de_estado> --> cria um projeto com o gerenciador de estados especificado.
+-s <gerenciador_de_estado>
 
 Opções: 
 mobx / flutter_bloc / rxdart

--- a/README-PT.md
+++ b/README-PT.md
@@ -80,7 +80,6 @@ E você vai ter essa estrutura:
 ![Folder example](/screenshots/start_cmd.png?raw=true)
 
 
-
 Flutter Bloc:
 
 ![Folder example](/screenshots/choose_state_management_flutter_bloc.PNG?raw=true)
@@ -103,6 +102,31 @@ Se você tiver o pacote flutter_bloc ou flutter_mobx no pubspec, a geração de 
 
 ![Exemplo de pasta](/screenshots/start_cmd.png)
 
+#### Opções
+O comando permite especificar o provedor e o gerenciador de estados utilizando as seguintes opções:
+* Provedor:
+```
+-p <nome_do_provedor>
+
+Opções:
+flutter_modular / bloc_pattern
+
+Exemplo:
+slidy start -p flutter_modular
+```
+* Gerenciador de estado: 
+```
+-s <gerenciador_de_estado> --> cria um projeto com o gerenciador de estados especificado.
+
+Opções: 
+mobx / flutter_bloc / rxdart
+Exemplo:
+slidy start -s mobx
+```
+* Provedor e gerenciador de estado:
+```
+slidy start -p flutter_modular -s mobx
+```
 
 ### run:
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ slidy start -s mobx
 ```
 slidy start -p flutter_modular -s mobx
 ```
+This command asks for permission to erase lib folder. If you don't want to see the warning, type the -e (erase) flag:
+```
+slidy start -p flutter_modular -s mobx -e
+```
 
 ### run:
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,31 @@ And you will get this Structure:
 
 If you have the flutter_bloc or flutter_mobx package in pubspec, the generation of pages, widgets, and bloc defaults to the installed manager default.
 
+#### Options
+The command allows to specify provider and state manager using the following options:
+* Provider:
+```
+-p <provider_name>
 
+Options:
+flutter_modular / bloc_pattern
 
+Example:
+slidy start -p flutter_modular
+```
+* State manager: 
+```
+-s <state_manager_name>
+
+Options: 
+mobx / flutter_bloc / rxdart
+Example:
+slidy start -s mobx
+```
+* Provider and state manager:
+```
+slidy start -p flutter_modular -s mobx
+```
 
 ### run:
 

--- a/lib/src/command/start_command.dart
+++ b/lib/src/command/start_command.dart
@@ -14,10 +14,24 @@ class StartCommand extends CommandBase {
             'Create a complete flutter project with Themes separated of main.dart, named Routes and locales Strings configured'
         //Add in future configured the release android sign
         );
+
+  argParser.addOption('providerSystem',
+      abbr: 'p',
+      help:
+          'Create a flutter project using an specified provider system. Options: flutter_modular / bloc_pattern'
+      //Add in future configured the release android sign
+      );
+
+  argParser.addOption('stateManagement',
+      abbr: 's',
+      help:
+          'Create a flutter project using an specified state management. Options: mobx / flutter_bloc / rxdart'
+      //Add in future configured the release android sign
+      );
   }
 
   @override
   void run() {
-    start(completeStart: argResults['complete'], providerSystem: argsLength(0) ? argResults.arguments[0] : null, stateManagement: argsLength(1) ? argResults.arguments[1] : null);
+    start(completeStart: argResults['complete'], providerSystem: argResults['providerSystem'], stateManagement: argResults['stateManagement']);
   }
 }

--- a/lib/src/command/start_command.dart
+++ b/lib/src/command/start_command.dart
@@ -19,19 +19,24 @@ class StartCommand extends CommandBase {
       abbr: 'p',
       help:
           'Create a flutter project using an specified provider system. Options: flutter_modular / bloc_pattern'
-      //Add in future configured the release android sign
       );
 
   argParser.addOption('stateManagement',
       abbr: 's',
       help:
           'Create a flutter project using an specified state management. Options: mobx / flutter_bloc / rxdart'
-      //Add in future configured the release android sign
+      );
+
+  argParser.addFlag('isCreate',
+      abbr: 'e',
+      negatable: false,
+      help:
+          'Erase lib dir'
       );
   }
 
   @override
   void run() {
-    start(completeStart: argResults['complete'], providerSystem: argResults['providerSystem'], stateManagement: argResults['stateManagement']);
+    start(completeStart: argResults['complete'], providerSystem: argResults['providerSystem'], stateManagement: argResults['stateManagement'], isCreate: argResults['isCreate']);
   }
 }

--- a/lib/src/command/start_command.dart
+++ b/lib/src/command/start_command.dart
@@ -17,6 +17,6 @@ class StartCommand extends CommandBase {
 
   @override
   void run() {
-    start(argResults['complete']);
+    start(completeStart: argResults['complete'], providerSystem: argResults.arguments[0], stateManagement: argResults.arguments[1]);
   }
 }

--- a/lib/src/command/start_command.dart
+++ b/lib/src/command/start_command.dart
@@ -2,6 +2,7 @@ import 'package:slidy/slidy.dart';
 
 class StartCommand extends CommandBase {
   final name = "start";
+  bool argsLength(int n) => argResults.arguments.length > n; 
   final description =
       "Create a basic structure for your project (confirm that you have no data in the \"lib\" folder).";
 
@@ -17,6 +18,6 @@ class StartCommand extends CommandBase {
 
   @override
   void run() {
-    start(completeStart: argResults['complete'], providerSystem: argResults.arguments[0], stateManagement: argResults.arguments[1]);
+    start(completeStart: argResults['complete'], providerSystem: argsLength(0) ? argResults.arguments[0] : null, stateManagement: argsLength(1) ? argResults.arguments[1] : null);
   }
 }

--- a/lib/src/modules/create.dart
+++ b/lib/src/modules/create.dart
@@ -36,7 +36,7 @@ void startFlutterCreate(String projectName, String projectDescription,
 }
 
 void startSlidyCreate(String projectName, Function selectedProvider, Function selectedState) {
-  start(false, true, Directory('$projectName/lib'), Tuple2(selectedProvider, selectedState));
+  start(completeStart: false, isCreate: true, dir: Directory('$projectName/lib'), tuple: Tuple2(selectedProvider, selectedState));
 }
 
 List<String> createFlutterArgs(String projectName, String projectDescription,

--- a/lib/src/modules/start.dart
+++ b/lib/src/modules/start.dart
@@ -20,6 +20,17 @@ bool _isContinue() {
   }
 }
 
+Map<String, int> providerSystemOptions = {
+  'flutter_modular': 1,
+  'bloc_pattern': 2
+};
+
+Map<String, int> stateManagementOptions = {
+  'mobx': 1,
+  'flutter_bloc': 2,
+  'rxdart': 3
+};
+
 int stateCLIOptions(String title, List<String> options) {
   stdin.echoMode = false;
   stdin.lineMode = false;
@@ -147,11 +158,8 @@ Future start({completeStart,
   dir ??= Directory('lib');
   providerSystem ??= '';
   stateManagement ??= '';
-  tuple ??= Tuple2(blocOrModular(
-    providerSystem == 'flutter_modular' ? 0 : providerSystem == 'bloc_pattern' ? 1 : null
-  ), selecStateManagement(
-    stateManagement == "mobx" ? 0 : stateManagement == "flutter_bloc" ? 1 : stateManagement == "rxdart" ? 2 : null 
-  ));
+  tuple ??= Tuple2(blocOrModular(providerSystemOptions[providerSystem]), 
+                  selecStateManagement(stateManagementOptions[stateManagement]));
   await isContinue(dir, isCreate ? 1 : null);
   await tuple.item1();
   await tuple.item2();

--- a/lib/src/modules/start.dart
+++ b/lib/src/modules/start.dart
@@ -141,12 +141,17 @@ Future isContinue(Directory dir, [int selected]) async {
   }
 }
 
-Future start(completeStart,
-    [bool isCreate = false,
-    Directory dir,
-    Tuple2<Function, Function> tuple]) async {
+Future start({completeStart,
+ bool isCreate = false, Directory dir, Tuple2<Function, Function> tuple,
+ String providerSystem, String stateManagement}) async {
   dir ??= Directory('lib');
-  tuple ??= Tuple2(blocOrModular(), selecStateManagement());
+  providerSystem ??= '';
+  stateManagement ??= '';
+  tuple ??= Tuple2(blocOrModular(
+    providerSystem == 'flutter_modular' ? 0 : providerSystem == 'bloc_pattern' ? 1 : null
+  ), selecStateManagement(
+    stateManagement == "mobx" ? 0 : stateManagement == "flutter_bloc" ? 1 : stateManagement == "rxdart" ? 2 : null 
+  ));
   await isContinue(dir, isCreate ? 1 : null);
   await tuple.item1();
   await tuple.item2();

--- a/lib/src/modules/start.dart
+++ b/lib/src/modules/start.dart
@@ -156,8 +156,6 @@ Future start({completeStart,
  bool isCreate = false, Directory dir, Tuple2<Function, Function> tuple,
  String providerSystem, String stateManagement}) async {
   dir ??= Directory('lib');
-  providerSystem ??= '';
-  stateManagement ??= '';
   tuple ??= Tuple2(blocOrModular(providerSystemOptions[providerSystem]), 
                   selecStateManagement(stateManagementOptions[stateManagement]));
   await isContinue(dir, isCreate ? 1 : null);

--- a/lib/src/modules/start.dart
+++ b/lib/src/modules/start.dart
@@ -21,14 +21,14 @@ bool _isContinue() {
 }
 
 Map<String, int> providerSystemOptions = {
-  'flutter_modular': 1,
-  'bloc_pattern': 2
+  'flutter_modular': 0,
+  'bloc_pattern': 1
 };
 
 Map<String, int> stateManagementOptions = {
-  'mobx': 1,
-  'flutter_bloc': 2,
-  'rxdart': 3
+  'mobx': 0,
+  'flutter_bloc': 1,
+  'rxdart': 2
 };
 
 int stateCLIOptions(String title, List<String> options) {
@@ -134,20 +134,19 @@ Function selecStateManagement([int selected, String directory]) {
 Future isContinue(Directory dir, [int selected]) async {
   if (await dir.exists()) {
     if (dir.listSync().isNotEmpty) {
-      selected = stateCLIOptions(
-          'This command will delete everything inside the \"lib /\" and \"test\" folders.',
-          [
-            'No',
-            'Yes',
-          ]);
-
-      if (selected == 1) {
-        output.msg("Removing lib folder");
-        await dir.delete(recursive: true);
-      } else {
-        output.error('The lib folder must be empty');
-        exit(1);
+      selected ??= stateCLIOptions(
+        'This command will delete everything inside the \"lib /\" and \"test\" folders.',
+        [
+          'No',
+          'Yes',
+        ]);
       }
+    if (selected == 1) {
+      output.msg('Removing lib folder');
+      await dir.delete(recursive: true);
+    } else {
+      output.error('The lib folder must be empty');
+      exit(1);
     }
   }
 }


### PR DESCRIPTION
Adicionei as opções de provider (-p) e gerenciador de estados (-s) ao comando start. Além disso, adicionei a flag -e (erase) para que o usuário não veja o aviso de que o slidy apagará a pasta lib. Por último, atualizei os dois arquivos Readme 