### PR TITLE
Convert to single quotes and adding override annotate in methods

### DIFF
--- a/lib/src/command/create_command.dart
+++ b/lib/src/command/create_command.dart
@@ -2,43 +2,47 @@ import 'package:args/command_runner.dart';
 import 'package:slidy/slidy.dart';
 
 class CreateCommand extends CommandBase {
-  final name = "create";
-  final description = "Create a Flutter project with basic structure";
-  final invocationSuffix = "<project name>";
+  @override
+  final name = 'create';
+  @override
+  final description = 'Create a Flutter project with basic structure';
+  @override
+  final invocationSuffix = '<project name>';
 
   CreateCommand() {
     argParser.addOption('description',
         abbr: 'd',
         help:
-            "The description to use for your new Flutter project. This string ends up in the pubspec.yaml file. (defaults to \"A new Flutter project. Created by Slidy\")");
+            'The description to use for your new Flutter project. This string ends up in the pubspec.yaml file. (defaults to \"A new Flutter project. Created by Slidy\")');
 
     argParser.addOption('org',
         abbr: 'o',
         help:
-            "The organization responsible for your new Flutter project, in reverse domain name notation. This string is used in Java package names and as prefix in the iOS bundle identifier. (defaults to \"com.example\")");
+            'The organization responsible for your new Flutter project, in reverse domain name notation. This string is used in Java package names and as prefix in the iOS bundle identifier. (defaults to \"com.example\")');
 
     argParser.addFlag('kotlin',
-        abbr: 'k', negatable: false, help: "use kotlin in Android project");
+        abbr: 'k', negatable: false, help: 'use kotlin in Android project');
 
     argParser.addFlag('swift',
-        abbr: 's', negatable: false, help: "use swift in ios project");
+        abbr: 's', negatable: false, help: 'use swift in ios project');
 
     argParser.addFlag('androidx',
-        abbr: 'x', negatable: false, help: "use androidx on android project");
+        abbr: 'x', negatable: false, help: 'use androidx on android project');
   }
 
+  @override
   void run() {
     if (argResults.rest.isEmpty) {
       throw UsageException(
-          "project name not passed for a create command", usage);
+          'project name not passed for a create command', usage);
     } else {
       create(
           argResults.rest.first,
-          argResults["description"],
-          argResults["org"],
-          argResults["kotlin"],
-          argResults["swift"],
-          argResults["androidx"]);
+          argResults['description'],
+          argResults['org'],
+          argResults['kotlin'],
+          argResults['swift'],
+          argResults['androidx']);
     }
   }
 }

--- a/lib/src/command/generate_command.dart
+++ b/lib/src/command/generate_command.dart
@@ -6,10 +6,12 @@ import 'package:slidy/src/command/sub_command/generate_service_sub_command.dart'
 import 'package:slidy/src/command/sub_command/generate_test_sub_command.dart';
 
 class GenerateCommand extends CommandBase {
-  final name = "generate";
+  @override
+  final name = 'generate';
+  @override
   final description =
-      "Creates a module, page, widget or repository according to the option.";
-  final abbr = "g";
+      'Creates a module, page, widget or repository according to the option.';
+  final abbr = 'g';
 
   GenerateCommand() {
     addSubcommand(GenerateModuleSubCommand());
@@ -34,5 +36,6 @@ class GenerateCommand extends CommandBase {
 }
 
 class GenerateCommandAbbr extends GenerateCommand {
-  final name = "g";
+  @override
+  final name = 'g';
 }

--- a/lib/src/command/install_command.dart
+++ b/lib/src/command/install_command.dart
@@ -2,24 +2,28 @@ import 'package:args/command_runner.dart';
 import 'package:slidy/slidy.dart';
 
 class InstallCommand extends CommandBase {
-  final name = "install";
-  final description = "Install (or update) a new package or packages:";
+  @override
+  final name = 'install';
+  @override
+  final description = 'Install (or update) a new package or packages:';
 
   InstallCommand() {
     argParser.addFlag('dev',
         negatable: false,
-        help: "Install (or update) a package in a dev dependency");
+        help: 'Install (or update) a package in a dev dependency');
   }
 
+  @override
   void run() {
     if (argResults.rest.isEmpty) {
-      throw UsageException("value not passed for a module command", usage);
+      throw UsageException('value not passed for a module command', usage);
     } else {
-      install(argResults.rest, argResults["dev"]);
+      install(argResults.rest, argResults['dev']);
     }
   }
 }
 
 class InstallCommandAbbr extends InstallCommand {
-  final name = "i";
+  @override
+  final name = 'i';
 }

--- a/lib/src/command/start_command.dart
+++ b/lib/src/command/start_command.dart
@@ -1,10 +1,12 @@
 import 'package:slidy/slidy.dart';
 
 class StartCommand extends CommandBase {
-  final name = "start";
+  @override
+  final name = 'start';
   bool argsLength(int n) => argResults.arguments.length > n;
+  @override
   final description =
-      "Create a basic structure for your project (confirm that you have no data in the \"lib\" folder).";
+      '"Create a basic structure for your project (confirm that you have no data in the \"lib\" folder)."';
 
   StartCommand() {
     argParser.addFlag('complete',

--- a/lib/src/command/sub_command/generate_page_sub_command.dart
+++ b/lib/src/command/sub_command/generate_page_sub_command.dart
@@ -2,12 +2,14 @@ import 'package:args/command_runner.dart';
 import 'package:slidy/slidy.dart';
 
 class GeneratePageSubCommand extends CommandBase {
-  final name = "page";
-  final description = "Creates a page";
+  @override
+  final name = 'page';
+  @override
+  final description = 'Creates a page';
 
   GeneratePageSubCommand() {
     argParser.addFlag('bloc',
-        abbr: 'b', negatable: false, help: "Creates a page without Bloc file");
+        abbr: 'b', negatable: false, help: 'Creates a page without Bloc file');
     argParser.addFlag('flutter_bloc',
         abbr: 'f', negatable: true, help: 'using flutter_bloc package'
         //Add in future configured the release android sign
@@ -18,15 +20,17 @@ class GeneratePageSubCommand extends CommandBase {
         );
   }
 
+  @override
   void run() {
     if (argResults.rest.isEmpty) {
-      throw UsageException("value not passed for a module command", usage);
+      throw UsageException('value not passed for a module command', usage);
     } else {
-      Generate.page(argResults.rest.first, argResults["bloc"], argResults["flutter_bloc"], argResults["mobx"]);
+      Generate.page(argResults.rest.first, argResults['bloc'], argResults['flutter_bloc'], argResults['mobx']);
     }
   }
 }
 
 class GeneratePageAbbrSubCommand extends GeneratePageSubCommand {
-  final name = "p";
+  @override
+  final name = 'p';
 }

--- a/lib/src/command/sub_command/generate_repository_sub_command.dart
+++ b/lib/src/command/sub_command/generate_repository_sub_command.dart
@@ -2,8 +2,10 @@ import 'package:args/command_runner.dart';
 import 'package:slidy/slidy.dart';
 
 class GenerateRepositorySubCommand extends CommandBase {
-  final name = "repository";
-  final description = "Creates a repository";
+  @override
+  final name = 'repository';
+  @override
+  final description = 'Creates a repository';
 
   GenerateRepositorySubCommand() {
     argParser.addFlag('notest',
@@ -15,15 +17,17 @@ class GenerateRepositorySubCommand extends CommandBase {
         );
   }
 
+  @override
   void run() {
     if (argResults.rest.isEmpty) {
-      throw UsageException("value not passed for a module command", usage);
+      throw UsageException('value not passed for a module command', usage);
     } else {
-      Generate.repository(argResults.rest.first, !argResults["notest"]);
+      Generate.repository(argResults.rest.first, !argResults['notest']);
     }
   }
 }
 
 class GenerateRepositoryAbbrSubCommand extends GenerateRepositorySubCommand {
-  final name = "r";
+  @override
+  final name = 'r';
 }

--- a/lib/src/command/sub_command/generate_widget_sub_command.dart
+++ b/lib/src/command/sub_command/generate_widget_sub_command.dart
@@ -2,18 +2,20 @@ import 'package:args/command_runner.dart';
 import 'package:slidy/slidy.dart';
 
 class GenerateWidgetSubCommand extends CommandBase {
-  final name = "widget";
-  final description = "Creates a widget";
+  @override
+  final name = 'widget';
+  @override
+  final description = 'Creates a widget';
 
   GenerateWidgetSubCommand() {
     argParser.addFlag('bloc',
         abbr: 'b',
         negatable: false,
-        help: "Creates a widget without Bloc file");
+        help: 'Creates a widget without Bloc file');
     argParser.addFlag('suffix',
         abbr: 's',
         negatable: false,
-        help: "Creates a widget without a \"Widget\" suffix.");
+        help: 'Creates a widget without a \"Widget\" suffix.');
     argParser.addFlag('flutter_bloc',
         abbr: 'f', negatable: true, help: 'using flutter_bloc package'
         //Add in future configured the release android sign
@@ -24,16 +26,18 @@ class GenerateWidgetSubCommand extends CommandBase {
         );
   }
 
+  @override
   void run() {
     if (argResults.rest.isEmpty) {
-      throw UsageException("value not passed for a module command", usage);
+      throw UsageException('value not passed for a module command', usage);
     } else {
       Generate.widget(
-          argResults.rest.first, argResults["bloc"], argResults["suffix"], argResults["flutter_bloc"], argResults["mobx"]);
+          argResults.rest.first, argResults['bloc'], argResults['suffix'], argResults['flutter_bloc'], argResults['mobx']);
     }
   }
 }
 
 class GenerateWidgetAbbrSubCommand extends GenerateWidgetSubCommand {
-  final name = "w";
+  @override
+  final name = 'w';
 }

--- a/lib/src/command/uninstall_command.dart
+++ b/lib/src/command/uninstall_command.dart
@@ -2,19 +2,21 @@ import 'package:args/command_runner.dart';
 import 'package:slidy/slidy.dart';
 
 class UninstallCommand extends CommandBase {
-  final name = "uninstall";
-  final description = "Remove a package";
+  @override
+  final name = 'uninstall';
+  @override
+  final description = 'Remove a package';
 
   UninstallCommand() {
     argParser.addFlag('dev',
-        negatable: false, help: "Remove a package in a dev dependency");
+        negatable: false, help: 'Remove a package in a dev dependency');
   }
 
   void run() {
     if (argResults.rest.isEmpty) {
-      throw UsageException("value not passed for a module command", usage);
+      throw UsageException('value not passed for a module command', usage);
     } else {
-      uninstall(argResults.rest, argResults["dev"]);
+      uninstall(argResults.rest, argResults['dev']);
     }
   }
 }

--- a/lib/src/command/update_command.dart
+++ b/lib/src/command/update_command.dart
@@ -2,19 +2,21 @@ import 'package:args/command_runner.dart';
 import 'package:slidy/slidy.dart';
 
 class UpdateCommand extends CommandBase {
-  final name = "update";
-  final description = "Update a new package or packages.";
+  @override
+  final name = 'update';
+  @override
+  final description = 'Update a new package or packages.';
 
   UpdateCommand() {
     argParser.addFlag('dev',
-        negatable: false, help: "Update a package in a dev dependency");
+        negatable: false, help: 'Update a package in a dev dependency');
   }
 
   void run() {
     if (argResults.rest.isEmpty) {
-      throw UsageException("value not passed for a module command", usage);
+      throw UsageException('value not passed for a module command', usage);
     } else {
-      update(argResults.rest, argResults["dev"]);
+      update(argResults.rest, argResults['dev']);
     }
   }
 }

--- a/lib/src/command/upgrade_command.dart
+++ b/lib/src/command/upgrade_command.dart
@@ -1,9 +1,12 @@
 import 'package:slidy/slidy.dart';
 
 class UpgradeCommand extends CommandBase {
-  final name = "upgrade";
-  final description = "Upgrade the Slidy version";
+  @override
+  final name = 'upgrade';
+  @override
+  final description = 'Upgrade the Slidy version';
 
+  @override
   void run() {
     upgrade();
   }


### PR DESCRIPTION
Hello,

Following good code practices, I converted double quotes into single quotes, as recommended in the documentation and can be consulted on this [link](https://dart-lang.github.io/linter/lints/prefer_single_quotes.html).

@Override has been included in methods to improve code readability and help protect against involuntary replacement of superclass members, as recommended in the publication and consider being accessed by this [link](https://dart-lang.github.io/linter/lints/annotate_overrides.html).

Consider the analysis of this PR.

:)