### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ slidy start -s mobx
 slidy start -p flutter_modular -s mobx
 ```
 
-This command asks for permission to erase lib folder. If you don't want to see the warning, type the -e (erase) flag:
+This command asks for permission to erase lib folder. If you don't want to see the warning, type the -f (force) flag:
 
 ```bash
-slidy start -p flutter_modular -s mobx -e
+slidy start -p flutter_modular -s mobx -f
 ```
 
 ### run:


### PR DESCRIPTION
A opção slidy strat -e não funciona e não existe quando pesquiso com slidy start -help, porém a slidy start -f funciona com o propósito de pular a o aviso sobre apagar os arquivos, e consta na listagem do -help.