### PR TITLE
Add annotation @JsonSerializable to when create a model

### DIFF
--- a/lib/src/modules/generate.dart
+++ b/lib/src/modules/generate.dart
@@ -10,6 +10,9 @@ import 'package:slidy/src/utils/output_utils.dart' as output;
 
 import '../utils/utils.dart';
 
+final PACKAGE_JSON_ANNOTATION = 'json_annotation';
+final PACKAGE_JSON_SERIALIZABLE = 'json_serializable';
+
 class Generate {
   static Future module(
       String path, bool createCompleteModule, bool noroute) async {
@@ -213,11 +216,35 @@ class Generate {
   }
 
   static void model(List<String> path,
-      [bool isTest = false, bool isReactive = false]) {
-    file_utils.createFile(
+      [bool isTest = false, bool isReactive = false]) async {
+
+    var templateModel;
+
+    var getJsonDependencies = await Future.wait([
+      checkDependency(PACKAGE_JSON_ANNOTATION),
+      checkDevDependency(PACKAGE_JSON_SERIALIZABLE)
+    ]);
+
+    final checkJsonDependencies = getJsonDependencies.first && getJsonDependencies.last;
+
+    if (isReactive) {
+      if (checkJsonDependencies) {
+        templateModel = templates.modelRxGeneratorJsonSerializable;
+      } else {
+        templateModel = templates.modelRxGenerator;
+      }
+    } else {
+      if (checkJsonDependencies) {
+        templateModel = templates.modelGeneratorJsonSerializable;
+      } else {
+        templateModel = templates.modelGenerator;
+      }
+    }
+  
+    await file_utils.createFile(
       '${mainDirectory}${path.first}',
       'model',
-      isReactive ? templates.modelRxGenerator : templates.modelGenerator,
+      templateModel,
       ignoreSuffix: false,
     );
   }

--- a/lib/src/templates/generator/model_generator.dart
+++ b/lib/src/templates/generator/model_generator.dart
@@ -1,5 +1,46 @@
 import 'package:slidy/src/utils/object_generate.dart';
 
+String modelGeneratorJsonSerializable(ObjectGenerate obj) => '''
+import 'package:json_annotation/json_annotation.dart';
+
+part '${obj.name.toLowerCase()}_model.g.dart';
+
+@JsonSerializable()
+class ${obj.name}Model {
+
+  String name;
+
+  ${obj.name}Model({ this.name });
+
+  factory ${obj.name}Model.fromJson(Map<String, dynamic> json) => _\$${obj.name}ModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _\$${obj.name}ModelToJson(this);
+}
+''';
+
+String modelRxGeneratorJsonSerializable(ObjectGenerate obj) => '''
+import 'package:mobx/mobx.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part '${obj.name.toLowerCase()}_model.g.dart';
+
+@JsonSerializable()
+class ${obj.name}Model extends _${obj.name}ModelBase with _\$${obj.name}Model {
+  ${obj.name}Model({String name}) : super(name: name);
+
+  factory ${obj.name}Model.fromJson(Map<String, dynamic> json) => _\$${obj.name}ModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _\$${obj.name}ModelToJson(this);
+}
+
+abstract class _${obj.name}ModelBase with Store {
+  @observable
+  String name;
+
+  _${obj.name}ModelBase({this.name});
+}
+  ''';
+
 String modelGenerator(ObjectGenerate obj) => '''
 class ${obj.name}Model {
 

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -37,6 +37,16 @@ Future<bool> checkDependency(String dep) async {
   }
 }
 
+Future<bool> checkDevDependency(String dep) async {
+  try {
+    var yaml = await getPubSpec();
+    return yaml.devDependencies.containsKey(dep);
+  } catch (e) {
+    print(e);
+    return false;
+  }
+}
+
 Future<String> getVersion() async {
   //PubSpec yaml = await getPubSpec(path: File.fromUri(Platform.script).parent.parent.path);
   File file =


### PR DESCRIPTION
I thought it would be interesting have on slidy a option of set the annotation to when create a model verify if exists the packages json_annotation and json_serializable and if exists set annotation `@JsonSerializable` in model.

![generate_model](https://user-images.githubusercontent.com/43169851/81482492-d42a6600-920d-11ea-9044-1708f61d2601.gif)
