### PR TITLE
Added "slidy localization" command

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -50,7 +50,8 @@ CommandRunner configureCommand(List<String> arguments) {
         ..addCommand(InstallCommandAbbr())
         ..addCommand(UninstallCommand())
         ..addCommand(CreateCommand())
-        ..addCommand(RevertCommand());
+        ..addCommand(RevertCommand())
+        ..addCommand(LocalizationCommand());
 
   runner.argParser.addFlag('version', abbr: 'v', negatable: false);
   return runner;

--- a/lib/slidy.dart
+++ b/lib/slidy.dart
@@ -8,6 +8,7 @@ export 'package:slidy/src/command/uninstall_command.dart';
 export 'package:slidy/src/command/update_command.dart';
 export 'package:slidy/src/command/upgrade_command.dart';
 export 'package:slidy/src/command/create_command.dart';
+export 'package:slidy/src/command/localization_command.dart';
 
 export 'package:slidy/src/command/sub_command/generate_module_sub_command.dart';
 export 'package:slidy/src/command/sub_command/generate_page_sub_command.dart';

--- a/lib/src/command/localization_command.dart
+++ b/lib/src/command/localization_command.dart
@@ -1,0 +1,18 @@
+import 'package:slidy/slidy.dart';
+import 'package:slidy/src/modules/localization.dart';
+
+class LocalizationCommand extends CommandBase {
+  @override
+  final name = 'localization';
+
+  @override
+  final description = 'automatically creates translation files';
+
+  @override
+  final invocationSuffix = '<project name>';
+
+  @override
+  void run() {
+    runCommand();
+  }
+}

--- a/lib/src/modules/localization.dart
+++ b/lib/src/modules/localization.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+import 'package:slidy/src/utils/output_utils.dart' as output;
+
+void runCommand() async {
+  try {
+    final yaml = File('pubspec.yaml');
+    var node = yaml.readAsStringSync();
+    var doc = loadYaml(node);
+
+    if (!(doc as Map).containsKey('localization_dir')) {
+      throw 'Please, add param "localization_dir" (localization directory of your project) in your pubspec.yaml';
+    }
+
+    String localizationPath = doc['localization_dir'];
+
+    if ((localizationPath ?? '') == '') {
+      throw 'Please, the param "localization_dir" can not be null';
+    }
+
+    final dartFiles = await getAllDartFiles();
+    final translations = dartFiles
+        .cast<File>()
+        .map(getI18nKeysFromFile)
+        .reduce((x, y) => x..addAll(y));
+
+    final jsonEncodedData = readJsonFiles(localizationPath);
+    final newFilesData = jsonEncodedData.map((file, content) {
+      final Map<String, dynamic> newContent = jsonDecode(content);
+      final itemsToAdd = translations.entries
+          .skipWhile((entry) => newContent.keys.contains(entry.key));
+      print('${itemsToAdd.length} items to add.');
+      newContent.addEntries(itemsToAdd);
+
+      var encoder = JsonEncoder.withIndent('  ');
+      return MapEntry(file, encoder.convert(newContent));
+    });
+    writeJsonFiles(newFilesData);
+
+    print('Items added successful.');
+
+    print('Replacing i18n comments');
+
+    dartFiles.cast<File>().forEach(removeI18nComments);
+  } catch (e) {
+    output.error(e);
+  }
+}
+
+String getLibDirectory() {
+  return r'lib';
+}
+
+void removeI18nComments(File file) {
+  final findRegex = RegExp(r'''[\'\"](.*)[\'\"].i18n\(.*\).*\/\/(.*)''');
+  final replaceRegex = RegExp(r'''\/\/(.*)''');
+
+  var data = file.readAsLinesSync();
+  var containsUpdate = false;
+  var newData = data.map((line) {
+    if (line.contains(findRegex)) {
+      containsUpdate = true;
+      return line.replaceAll(replaceRegex, '');
+    } else {
+      return line;
+    }
+  }).toList();
+  if (containsUpdate) {
+    file.writeAsStringSync("${newData.join('\n')}\n");
+    print('file ${file.path} updated');
+  }
+}
+
+Future<List<FileSystemEntity>> getAllDartFiles() async {
+  final files = <FileSystemEntity>[];
+  var dir = Directory(getLibDirectory());
+  final filesSubscription = dir
+      .list(recursive: true)
+      .where((file) => file.path.substring(file.path.length - 5) == '.dart')
+      .listen(files.add);
+
+  await filesSubscription.asFuture();
+  await filesSubscription.cancel();
+  return files;
+}
+
+//https://regexr.com/4pvrh
+Map<String, String> getI18nKeysFromFile(File file) {
+  final regex = RegExp(r'''[\'\"](.*)[\'\"].i18n\(.*\).*\/\/(.*)''');
+  final response = <String, String>{};
+  var data = file.readAsStringSync();
+  if (regex.hasMatch(data)) {
+    regex.allMatches(data).forEach((match) => (match.groupCount == 4)
+        ? response[match.group(3)] = match.group(3)
+        : response[match.group(1)] = match.group(2));
+  }
+  return response;
+}
+
+Map<File, String> readJsonFiles(String localizationPath) {
+  final response = <File, String>{};
+  final dir = Directory(localizationPath);
+  final files = dir.listSync();
+
+  for (var file in files) {
+    response[file] = (file as File).readAsStringSync();
+  }
+
+  return response;
+}
+
+void writeJsonFiles(Map<File, String> filesData) =>
+    filesData.forEach((file, content) => file.writeAsStringSync(content));


### PR DESCRIPTION
Added `slidy localization` command to help in use with [localization package](https://pub.dev/packages/localization).

This command get all `.i18n()` in code and trailing comments. If this key already exists, updates value in all localization files, else, inserts this key and your value in end of all localization files. 

In all cases, the comment is removed to mantain clean the code.

The localization directory is defined in root of `pubspec.yaml`, like this:
```
localization_dir: assets\language
```
**_[NOTE] Is recommended create this definition in file's end._**

### Example

<details>
<summary><b>Before command</b></summary><br/>

**pt_BR.json**
```json
{
  "login-label": "Usuário"
}
```

**login_page.dart**
```dart
import 'package:flutter/material.dart';
import 'package:localization/localization.dart';

class LoginPage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: Text("Login")),
      body: Column(
        children: [
          TextField(decoration: InputDecoration(labelText: "user-label".i18n())),
          TextField(decoration: InputDecoration(labelText: "password-label".i18n())), //Senha
        ],
      ),
    );
  }
}
```

</details>

<details>
<summary><b>After command</b></summary><br/>

**pt_BR.json**
```json
{
  "login-label": "Usuário",
  "password-label": "Senha"
}
```

**login_page.dart**
```dart
import 'package:flutter/material.dart';
import 'package:localization/localization.dart';

class LoginPage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: Text("Login")),
      body: Column(
        children: [
          TextField(decoration: InputDecoration(labelText: "user-label".i18n())),
          TextField(decoration: InputDecoration(labelText: "password-label".i18n())),
        ],
      ),
    );
  }
}
```
</details>