### PR TITLE
Update README

### DIFF
--- a/README-PT.md
+++ b/README-PT.md
@@ -409,6 +409,14 @@ class LoginPage extends StatelessWidget {
 
 ## Erros comuns:
 
+**Comando não encontrado: slidy**
+
+Em caso `command not found: slidy` ou `Comando não encontrado`, verifique se a variável de ambiente PATH está devidamente configurada (.bashrc, .bash_profile, .zshrc, etc.):
+
+```
+export PATH="$PATH":"$HOME/.pub-cache/bin"
+```
+
 **Não consegue atualizar:**
 1 - Primeiro desinstalar o Slidy no Flutter
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,15 @@ class LoginPage extends StatelessWidget {
 
 ## Common errors:
 
-**I cant update:**
+**Command not found: slidy**
+
+In case of `command not found: slidy`, check if the PATH environment variable is properly configured at your shell's config file (.bashrc, .bash_profile, .zshrc, etc.):
+
+```
+export PATH="$PATH":"$HOME/.pub-cache/bin"
+```
+
+**I can't update:**
 
 1 - First of all you need uninstall the Slidy on Flutter
 ```


### PR DESCRIPTION
Update README with a solution for `command not found: slidy` error.

---

Hoje comecei a usar e testar o slidy.

Eu segui o readme para instalação, instalei o dart e utilizei o `pub global activate slidy`, mas estava tendo o seguinte erro:`command not found: slidy`.

Após reinstalar, percebi que esqueci uma informação:

```
Warning: Pub installs executables into $HOME/.pub-cache/bin, which is not on your path.
You can fix that by adding this to your shell's config file (.bashrc, .bash_profile, etc.):

  export PATH="$PATH":"$HOME/.pub-cache/bin"
```

Não sei se isso possa acontecer com mais pessoas, mas adicionei ao README 😃 

