### PR TITLE
Add MacOS files on Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build/
 
 # Directory created by dartdoc
 doc/api/
+
+# MacOS
+.DS_Store


### PR DESCRIPTION
.DS_Store is a MacOS native file that should be ignored for Git