### PR TITLE
Changed pubspect.yml to pubspec.yml on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ slidy start
 ```     
 
 **run:** 
-     Run scripts placed in the "scripts" parameter in pubspect.yaml
+     Run scripts placed in the "scripts" parameter in pubspec.yaml
 ```  
 slidy run open_folder
 ```   


### PR DESCRIPTION
In the readme file, has an error, where is written "pubspect.yml", should be written "pubspec.yml"