### PR TITLE
Wrong import name when generate module with page

### DIFF
--- a/bin/commands/sub_command/generate_module_sub_command.dart
+++ b/bin/commands/sub_command/generate_module_sub_command.dart
@@ -50,7 +50,7 @@ class GenerateModuleSubCommand extends CommandBase {
     final selected = node?.value.keys.firstWhere((element) => smList.contains(element)) as String;
 
     await command.run(['generate', selected.replaceFirst('flutter_', ''), '${argResults!.rest.first}/${templateFile.fileName}', '--page']);
-    templateFile = await TemplateFile.getInstance('${argResults!.rest.first}/${templateFile.fileName}', 'Page');
+    templateFile = await TemplateFile.getInstance('${argResults!.rest.first}/${templateFile.fileName}', 'page');
 
     await utils.injectParentModuleRouting('/', '${templateFile.fileNameWithUppeCase}Page()', templateFile.import, templateFile.file.parent);
   }


### PR DESCRIPTION
command: 
`slidy generate module modules/costumers/edit -c`

edit_module.dart imports:
![image](https://user-images.githubusercontent.com/27743936/117080263-dab1c780-ad13-11eb-9073-46d89ae054be.png)
