### PR TITLE
fix: fluter_modular_test deprecated changing to modular_test package

### DIFF
--- a/bin/commands/start_command.dart
+++ b/bin/commands/start_command.dart
@@ -15,10 +15,12 @@ class StartCommand extends CommandBase {
   final name = 'start';
   bool argsLength(int n) => (argResults?.arguments.length ?? 0) > n;
   @override
-  final description = '"Create a basic structure for your project (confirm that you have no data in the \"lib\" folder)."';
+  final description =
+      '"Create a basic structure for your project (confirm that you have no data in the \"lib\" folder)."';
 
   StartCommand() {
-    argParser.addFlag('force', abbr: 'f', negatable: false, help: 'Erase lib dir');
+    argParser.addFlag('force',
+        abbr: 'f', negatable: false, help: 'Erase lib dir');
   }
 
   int stateCLIOptions(String title, List<String> options) {
@@ -83,10 +85,12 @@ class StartCommand extends CommandBase {
     final dirTest = Directory('test');
 
     if (await dirLib.exists()) {
-      selected ??= stateCLIOptions('This command will delete everything inside the \'lib/\' and \'test\/\' folders.', [
-        'No',
-        'Yes',
-      ]);
+      selected ??= stateCLIOptions(
+          'This command will delete everything inside the \'lib/\' and \'test\/\' folders.',
+          [
+            'No',
+            'Yes',
+          ]);
     } else {
       selected = 2;
       if (await dirLib.exists()) {
@@ -117,98 +121,179 @@ class StartCommand extends CommandBase {
 
     await isContinue((argResults?['force'] == true) ? 1 : null);
 
-    var result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/main.dart'), key: 'main'));
+    var result = await Slidy.instance.template.createFile(
+        info: TemplateInfo(
+            yaml: mainFile, destiny: File('lib/main.dart'), key: 'main'));
     execute(result);
-    result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/app_module.dart'), key: 'app_module'));
+    result = await Slidy.instance.template.createFile(
+        info: TemplateInfo(
+            yaml: mainFile,
+            destiny: File('lib/app/app_module.dart'),
+            key: 'app_module'));
     execute(result);
-    result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/app_widget.dart'), key: 'app_widget'));
+    result = await Slidy.instance.template.createFile(
+        info: TemplateInfo(
+            yaml: mainFile,
+            destiny: File('lib/app/app_widget.dart'),
+            key: 'app_widget'));
     execute(result);
 
     //install packages
-    result = await Slidy.instance.instalation.install(package: PackageName('flutter_modular'));
+    result = await Slidy.instance.instalation
+        .install(package: PackageName('flutter_modular'));
     execute(result);
 
     switch (resultStateManagement) {
       case 0:
         //Instal flutter_triple
-        result = await Slidy.instance.instalation.install(package: PackageName('flutter_triple', isDev: false));
+        result = await Slidy.instance.instalation
+            .install(package: PackageName('flutter_triple', isDev: false));
         execute(result);
         //Instal rx_notifier
-        result = await Slidy.instance.instalation.install(package: PackageName('triple_test', isDev: true));
+        result = await Slidy.instance.instalation
+            .install(package: PackageName('triple_test', isDev: true));
         execute(result);
         //Create a controller
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_store.dart'), key: 'triple'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_store.dart'),
+                key: 'triple'));
         execute(result);
         //Page
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_page.dart'), key: 'home_page_triple'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_page.dart'),
+                key: 'home_page_triple'));
         execute(result);
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_module.dart'), key: 'home_module_triple'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_module.dart'),
+                key: 'home_module_triple'));
         execute(result);
 
         break;
       case 1:
         //Instal mobx
-        result = await Slidy.instance.instalation.install(package: PackageName('mobx', isDev: false));
+        result = await Slidy.instance.instalation
+            .install(package: PackageName('mobx', isDev: false));
         execute(result);
         //Instal flutter_mobx
-        result = await Slidy.instance.instalation.install(package: PackageName('flutter_mobx', isDev: false));
+        result = await Slidy.instance.instalation
+            .install(package: PackageName('flutter_mobx', isDev: false));
         execute(result);
 
         //Instal mobx_codegen
-        result = await Slidy.instance.instalation.install(package: PackageName('mobx_codegen', isDev: true));
+        result = await Slidy.instance.instalation
+            .install(package: PackageName('mobx_codegen', isDev: true));
         execute(result);
         //Create a mobx
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_store.dart'), key: 'mobx'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_store.dart'),
+                key: 'mobx'));
         execute(result);
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_store.g.dart'), key: 'mobx_g'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_store.g.dart'),
+                key: 'mobx_g'));
         execute(result);
         //Page
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_page.dart'), key: 'home_page_mobx'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_page.dart'),
+                key: 'home_page_mobx'));
         execute(result);
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_module.dart'), key: 'home_module_mobx'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_module.dart'),
+                key: 'home_module_mobx'));
         execute(result);
 
         break;
       case 2:
         //Instal flutter_bloc
-        result = await Slidy.instance.instalation.install(package: PackageName('flutter_bloc@7.0.0-nullsafety.4', isDev: false));
+        result = await Slidy.instance.instalation.install(
+            package:
+                PackageName('flutter_bloc@7.0.0-nullsafety.4', isDev: false));
         execute(result);
         //Instal bloc_test
-        result = await Slidy.instance.instalation.install(package: PackageName('bloc_test@8.0.0-nullsafety.4', isDev: true));
+        result = await Slidy.instance.instalation.install(
+            package: PackageName('bloc_test@8.0.0-nullsafety.4', isDev: true));
         execute(result);
         //Create a cubit
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/counter_cubit.dart'), key: 'cubit'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/counter_cubit.dart'),
+                key: 'cubit'));
         execute(result);
         //Page
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_page.dart'), key: 'home_page_cubit'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_page.dart'),
+                key: 'home_page_cubit'));
         execute(result);
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_module.dart'), key: 'home_module_cubit'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_module.dart'),
+                key: 'home_module_cubit'));
         execute(result);
         break;
       case 3:
         //Instal rxdart
-        result = await Slidy.instance.instalation.install(package: PackageName('rxdart', isDev: false));
+        result = await Slidy.instance.instalation
+            .install(package: PackageName('rxdart', isDev: false));
         execute(result);
         //Create a rxdart
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_controller.dart'), key: 'rx_dart'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_controller.dart'),
+                key: 'rx_dart'));
         execute(result);
 
         //Page
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_page.dart'), key: 'home_page_rx_dart'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_page.dart'),
+                key: 'home_page_rx_dart'));
         execute(result);
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_module.dart'), key: 'home_module_rx_dart'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_module.dart'),
+                key: 'home_module_rx_dart'));
         execute(result);
 
         break;
       default:
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_page.dart'), key: 'home_page'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_page.dart'),
+                key: 'home_page'));
         execute(result);
-        result = await Slidy.instance.template.createFile(info: TemplateInfo(yaml: mainFile, destiny: File('lib/app/modules/home/home_module.dart'), key: 'home_module'));
+        result = await Slidy.instance.template.createFile(
+            info: TemplateInfo(
+                yaml: mainFile,
+                destiny: File('lib/app/modules/home/home_module.dart'),
+                key: 'home_module'));
         execute(result);
     }
 
     //devs
-    result = await Slidy.instance.instalation.install(package: PackageName('flutter_modular_test', isDev: true));
+    result = await Slidy.instance.instalation
+        .install(package: PackageName('modular_test', isDev: true));
     execute(result);
   }
 

--- a/bin/templates/module.dart
+++ b/bin/templates/module.dart
@@ -14,7 +14,7 @@ module: |
   }
 module_test: |
   import 'package:flutter_modular/flutter_modular.dart';
-  import 'package:flutter_modular_test/flutter_modular_test.dart';
+  import 'package:modular_test/modular_test.dart';
   import 'package:flutter_test/flutter_test.dart';
   $arg2
    

--- a/bin/templates/widgets.dart
+++ b/bin/templates/widgets.dart
@@ -26,7 +26,7 @@ page: |
 page_test: |
   $arg2
   import 'package:flutter_test/flutter_test.dart';
-  import 'package:flutter_modular_test/flutter_modular_test.dart';
+  import 'package:modular_test/modular_test.dart';
   
   main() {
     group('$arg1', () {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.2.2';
+const packageVersion = '3.2.2+1';


### PR DESCRIPTION
Correction to #264. The package flutter_modular_test has been deprecated and the new package is modular_test