### PR TITLE
Pass exclusive parameter in create and createAsync method override

### DIFF
--- a/lib/src/core/models/custom_file.dart
+++ b/lib/src/core/models/custom_file.dart
@@ -21,13 +21,13 @@ class CustomFile implements File {
   }
 
   @override
-  Future<File> create({bool recursive = false}) {
-    return _file.create(recursive: recursive);
+  Future<File> create({bool recursive = false, bool exclusive = false}) {
+    return _file.create(recursive: recursive, exclusive: exclusive);
   }
 
   @override
-  void createSync({bool recursive = false}) {
-    _file.createSync(recursive: recursive);
+  void createSync({bool recursive = false, bool exclusive = false}) {
+    _file.createSync(recursive: recursive, exclusive: exclusive);
   }
 
   @override


### PR DESCRIPTION
Theres an error caused by Breaking change https://github.com/dart-lang/sdk/issues/49647: 

File.create now takes new optional exclusive bool parameter, and when it is true the operation will fail if target file already exists.

that was introduced in version 2.19 of Dart.

This change comes from this issue:

https://github.com/dart-lang/sdk/issues/49647

I'm working on a local version of slidy that fixes this problem.
If the mainteners want, I can open a PR later with the correction for us to work on and release a new version with the fix;

Basically the solution start with the create and createAsync methods of File class that must be override like this:

```
  Future<File> create({bool exclusive = false, bool recursive = false}) {
    return _file.create(recursive: recursive);
  }

  @override
  void createSync({bool exclusive = false, bool recursive = false}) {
    _file.createSync(recursive: recursive);
  }
```